### PR TITLE
Cas23 addendum

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -47,6 +47,10 @@ use crate::{
     nexus_uri::BdevCreateDestroy,
 };
 
+use rpc::mayastor::{
+    ShareProtocol,
+};
+
 /// Common errors for nexus basic operations and child operations
 /// which are part of nexus object.
 #[derive(Debug, Snafu)]
@@ -195,6 +199,8 @@ pub struct Nexus {
     /// the handle to be used when sharing the nexus, this allows for the bdev
     /// to be shared with vbdevs on top
     pub(crate) share_handle: Option<String>,
+    /// frontend share protocol used when the nexus is published
+    pub share_protocol: ShareProtocol,
 }
 
 unsafe impl core::marker::Sync for Nexus {}
@@ -271,6 +277,7 @@ impl Nexus {
             nbd_disk: None,
             share_handle: None,
             size,
+            share_protocol: ShareProtocol::None,
         });
 
         n.bdev.set_uuid(match uuid {

--- a/mayastor/src/bdev/nexus/nexus_share.rs
+++ b/mayastor/src/bdev/nexus/nexus_share.rs
@@ -50,6 +50,8 @@ impl Nexus {
             _ => return Err(Error::InvalidShareProtocol {sp_value: share_proto as i32}),
         };
 
+        self.share_protocol = share_proto;
+
         // TODO for now we discard and ignore share_proto
 
         let name = if let Some(key) = key {


### PR DESCRIPTION
Store the share protocol used publish a nexus, so that correct actions can be determined at unpublish.