### PR TITLE
Use from_i32 instead of custom from function for fronted share protocol.

### DIFF
--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -345,6 +345,32 @@ describe('nexus', function() {
     });
   });
 
+  it('should fail to publish with ShareProtocol None', done => {
+      let args = {
+          uuid: UUID,
+          share: mayastorProtoConstants.ShareProtocol.None
+      };
+
+      client.PublishNexus(args, (err, data) => {
+          if (!err) return done(new Error('Expected error'));
+          assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
+          done();
+      });
+  });
+
+  it('should fail to publish with invalid ShareProtocol value of 100', done => {
+      let args = {
+          uuid: UUID,
+          share: 100,
+      };
+
+      client.PublishNexus(args, (err, data) => {
+          if (!err) return done(new Error('Expected error'));
+          assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
+          done();
+      });
+  });
+
   it('should publish the nexus using nbd', done => {
     // TODO: repeat this test for iSCSI and Nvmf
     client.PublishNexus({ uuid: UUID, share: mayastorProtoConstants.ShareProtocol.NBD }, (err, res) => {

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -62,17 +62,6 @@ fn name_to_uuid(name: &str) -> &str {
     }
 }
 
-/// Convert share protocol value to ShareProtocol for frontend use.
-/// Returns Option<ShareProtocol> or None.
-fn frontend_shareprotocol_from(spv : i32) -> Option<ShareProtocol> {
-    match spv  {
-        0 => None,
-        1 => Some(ShareProtocol::Nvmf),
-        2 => Some(ShareProtocol::Iscsi),
-        3 => Some(ShareProtocol::Nbd),
-        _ => None
-    }
-}
 
 pub(crate) fn register_rpc_methods() {
     // JSON rpc method to list the nexus and their states
@@ -143,15 +132,13 @@ pub(crate) fn register_rpc_methods() {
             let key: Option<String> =
                 if args.key == "" { None } else { Some(args.key) };
 
-            let spv = frontend_shareprotocol_from(args.share);
-            if spv.is_none() {
-                return Err(Error::InvalidShareProtocol {sp_value: args.share});
+            let share_proto = ShareProtocol::from_i32(args.share);
+            if share_proto.is_none() {
+                return Err(Error::InvalidShareProtocol {sp_value: args.share as i32});
             }
 
-            let share = spv.unwrap();
-
             let nexus = nexus_lookup(&args.uuid)?;
-            nexus.share(share, key).await.map(|device_path| PublishNexusReply {
+            nexus.share(share_proto.unwrap(), key).await.map(|device_path| PublishNexusReply {
                 device_path,
             })
         };


### PR DESCRIPTION
Invalid values received are handled correctly in the rpc code, i.e. nexus_rpc.rs
Invalid value SharedProtocol::None is handled correctly in the nexus share code, i.e. nexus_share.rs