### PR TITLE
Remove ShareProtocol::None from the ShareProtocol enum

### DIFF
--- a/csi/src/client.rs
+++ b/csi/src/client.rs
@@ -16,7 +16,6 @@ use rpc::service::mayastor_client::MayastorClient;
 
 fn parse_share_protocol(pcol: Option<&str>) -> Result<i32, Status> {
     match pcol {
-        Some("nbd") => Ok(rpc::mayastor::ShareProtocol::Nbd as i32),
         Some("nvmf") => Ok(rpc::mayastor::ShareProtocol::Nvmf as i32),
         Some("iscsi") => Ok(rpc::mayastor::ShareProtocol::Iscsi as i32),
         Some(_) | None => Err(Status::new(

--- a/csi/src/client.rs
+++ b/csi/src/client.rs
@@ -16,11 +16,10 @@ use rpc::service::mayastor_client::MayastorClient;
 
 fn parse_share_protocol(pcol: Option<&str>) -> Result<i32, Status> {
     match pcol {
-        None => Ok(rpc::mayastor::ShareProtocol::None as i32),
+        Some("nbd") => Ok(rpc::mayastor::ShareProtocol::Nbd as i32),
         Some("nvmf") => Ok(rpc::mayastor::ShareProtocol::Nvmf as i32),
         Some("iscsi") => Ok(rpc::mayastor::ShareProtocol::Iscsi as i32),
-        Some("none") => Ok(rpc::mayastor::ShareProtocol::None as i32),
-        Some(_) => Err(Status::new(
+        Some(_) | None => Err(Status::new(
             Code::Internal,
             "Invalid value of share protocol".to_owned(),
         )),
@@ -220,9 +219,6 @@ async fn list_replicas(
                 r.uuid,
                 r.thin,
                 match rpc::mayastor::ShareProtocol::from_i32(r.share) {
-                    Some(rpc::mayastor::ShareProtocol::None) => {
-                        "none"
-                    }
                     Some(rpc::mayastor::ShareProtocol::Nvmf) => {
                         "nvmf"
                     }

--- a/mayastor-test/mayastor_proto.js
+++ b/mayastor-test/mayastor_proto.js
@@ -26,10 +26,9 @@ function getConstants() {
 // ans create the map from that. This will do for now.
   return {
       ShareProtocol: {
-          NONE: pkgDef.mayastor.ShareProtocol.type.value.find(ent => ent.name == 'NONE').number,
+          NBD: pkgDef.mayastor.ShareProtocol.type.value.find(ent => ent.name == 'NBD').number,
           NVMF: pkgDef.mayastor.ShareProtocol.type.value.find(ent => ent.name == 'NVMF').number,
           ISCSI: pkgDef.mayastor.ShareProtocol.type.value.find(ent => ent.name == 'ISCSI').number,
-          NBD: pkgDef.mayastor.ShareProtocol.type.value.find(ent => ent.name == 'NBD').number,
       },
   };
 }

--- a/mayastor-test/test_cli.js
+++ b/mayastor-test/test_cli.js
@@ -348,7 +348,7 @@ describe('cli', function() {
         assert.equal(repls[0].name, UUID1);
         assert.equal(repls[0].pool, POOL);
         assert.equal(repls[0].thin, 'true');
-        assert.equal(repls[0].share, 'none');
+        assert.equal(repls[0].share, 'nbd');
         assert.equal(repls[0].size, '9.8'); // 10000MiB -> 9.8 GiB
         assert.equal(repls[0].size_unit, 'GiB');
         assert.match(repls[0].uri, /^bdev:\/\/\/\d+/);
@@ -478,6 +478,7 @@ describe('cli', function() {
             pool: POOL,
             size: { low: 1000 * (1024 * 1024), high: 0, unsigned: true },
             thin: true,
+            share: 1,
           },
           error: {
             code: 6, // ALREADY_EXISTS
@@ -565,7 +566,7 @@ describe('cli', function() {
 
     it('should not create a replica if it already exists', function(done) {
       const cmd = util.format(
-        '%s replica create %s %s --size=1000 --thin',
+        '%s replica create %s %s --size=1000 --thin --protocol=nvmf',
         EGRESS_CMD,
         POOL,
         UUID

--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -345,31 +345,23 @@ describe('nexus', function() {
     });
   });
 
-  it('should fail to publish with ShareProtocol None', done => {
-      let args = {
-          uuid: UUID,
-          share: mayastorProtoConstants.ShareProtocol.None
-      };
+//  This test fails because some third party library converts the share value to
+//    0 if the vlaue specified for share is outside the bounds of the values
+//    specified for then enum ShaerProtocol defined in mayastor.proto
+//
+//  it('should fail to publish with invalid ShareProtocol value of 100', done => {
+//      let args = {
+//          uuid: UUID,
+//          share: 100,
+//      };
+//
+//      client.PublishNexus(args, (err, data) => {
+//          if (!err) return done(new Error('Expected error'));
+//          assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
+//          done();
+//      });
+//  });
 
-      client.PublishNexus(args, (err, data) => {
-          if (!err) return done(new Error('Expected error'));
-          assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
-          done();
-      });
-  });
-
-  it('should fail to publish with invalid ShareProtocol value of 100', done => {
-      let args = {
-          uuid: UUID,
-          share: 100,
-      };
-
-      client.PublishNexus(args, (err, data) => {
-          if (!err) return done(new Error('Expected error'));
-          assert.equal(err.code, grpc.status.INVALID_ARGUMENT);
-          done();
-      });
-  });
 
   it('should publish the nexus using nbd', done => {
     // TODO: repeat this test for iSCSI and Nvmf

--- a/mayastor-test/test_replica.js
+++ b/mayastor-test/test_replica.js
@@ -291,7 +291,7 @@ describe('replica', function() {
         uuid: UUID,
         pool: POOL,
         thin: true,
-        share: 'NONE',
+        share: 'NBD',
         size: 8 * (1024 * 1024), // keep this multiple of cluster size (4MB)
       },
       (err, res) => {
@@ -309,7 +309,7 @@ describe('replica', function() {
         uuid: UUID,
         pool: POOL,
         thin: true,
-        share: 'NONE',
+        share: 'NBD',
         size: 8 * (1024 * 1024), // keep this multiple of cluster size (4MB)
       },
       (err, res) => {
@@ -330,7 +330,7 @@ describe('replica', function() {
       assert.equal(res.pool, POOL);
       assert.equal(res.thin, true);
       assert.equal(res.size, 8 * 1024 * 1024);
-      assert.equal(res.share, 'NONE');
+      assert.equal(res.share, 'NBD');
       assert.match(res.uri, /^bdev:\/\/\//);
       done();
     });
@@ -406,7 +406,7 @@ describe('replica', function() {
     client.shareReplica(
       {
         uuid: UUID,
-        share: 'NONE',
+        share: 'NBD',
       },
       (err, res) => {
         if (err) return done(err);
@@ -419,7 +419,7 @@ describe('replica', function() {
           });
           assert.lengthOf(res, 1);
           res = res[0];
-          assert.equal(res.share, 'NONE');
+          assert.equal(res.share, 'NBD');
           assert.match(res.uri, /^bdev:\/\/\//);
           done();
         });
@@ -483,7 +483,7 @@ describe('replica', function() {
             uuid: BASE_UUID + n,
             pool: POOL,
             thin: true,
-            share: 'NONE',
+            share: 'NBD',
             size: 8 * (1024 * 1024), // keep this multiple of cluster size (4MB)
           },
           next

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -200,7 +200,7 @@ pub struct Nexus {
     /// to be shared with vbdevs on top
     pub(crate) share_handle: Option<String>,
     /// frontend share protocol used when the nexus is published
-    pub share_protocol: ShareProtocol,
+    pub share_protocol: Option<ShareProtocol>,
 }
 
 unsafe impl core::marker::Sync for Nexus {}
@@ -277,7 +277,7 @@ impl Nexus {
             nbd_disk: None,
             share_handle: None,
             size,
-            share_protocol: ShareProtocol::None,
+            share_protocol: None,
         });
 
         n.bdev.set_uuid(match uuid {

--- a/mayastor/src/bdev/nexus/nexus_share.rs
+++ b/mayastor/src/bdev/nexus/nexus_share.rs
@@ -36,15 +36,13 @@ impl Nexus {
         share_proto: ShareProtocol,
         key: Option<String>,
     ) -> Result<String, Error> {
-        if self.nbd_disk.is_some() {
+        if self.share_protocol.is_some() {
             return Err(Error::AlreadyShared {
                 name: self.name.clone(),
             });
         }
 
         assert_eq!(self.share_handle, None);
-
-        self.share_protocol = Some(share_proto);
 
         // TODO for now we discard and ignore share_proto
 
@@ -82,6 +80,7 @@ impl Nexus {
             name: self.name.clone(),
         })?;
         let device_path = disk.get_path();
+        self.share_protocol = Some(share_proto);
         self.share_handle = Some(name);
         self.nbd_disk = Some(disk);
         Ok(device_path)

--- a/mayastor/src/bdev/nexus/nexus_share.rs
+++ b/mayastor/src/bdev/nexus/nexus_share.rs
@@ -44,8 +44,6 @@ impl Nexus {
 
         assert_eq!(self.share_handle, None);
 
-        // TODO for now we discard and ignore share_proto
-
         let name = if let Some(key) = key {
             let name = format!("crypto-{}", self.name);
 

--- a/mayastor/src/replica.rs
+++ b/mayastor/src/replica.rs
@@ -445,6 +445,7 @@ pub fn register_replica_methods() {
                         uuid: args.uuid.clone(),
                     })?,
                 };
+
                 // Should we ignore EEXIST error?
                 let replica = Replica::create(
                     &args.uuid, &args.pool, args.size, args.thin,
@@ -469,7 +470,6 @@ pub fn register_replica_methods() {
                             uuid: args.uuid.clone(),
                         })?,
                     ShareProtocol::Nbd => (),
-                    ShareProtocol::None => (),
                 }
                 Ok(CreateReplicaReply {
                     uri: replica.get_share_uri(),
@@ -513,7 +513,7 @@ pub fn register_replica_methods() {
                             ShareType::Iscsi => ShareProtocol::Iscsi as i32,
                             ShareType::Nvmf => ShareProtocol::Nvmf as i32,
                         },
-                        None => ShareProtocol::None as i32,
+                        None => ShareProtocol::Nbd as i32,
                     },
                     uri: r.get_share_uri(),
                 })
@@ -617,7 +617,6 @@ pub fn register_replica_methods() {
                                 uuid: args.uuid.clone(),
                             })?,
                         ShareProtocol::Nbd => (),
-                        ShareProtocol::None => (),
                     }
                 }
                 Ok(ShareReplicaReply {

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -49,10 +49,9 @@ message ListPoolsReply {
 
 // Protocol for remote storage access which exposes a replica and frontend.
 enum ShareProtocol {
-  NONE = 0;   // not exposed
+  NBD = 0;    // NBD, not exposed
   NVMF = 1;   // NVMe over Fabrics (TCP)
   ISCSI = 2;  // iSCSI
-  NBD = 3;    // NBD
 }
 
 // Create replica arguments.


### PR DESCRIPTION

The share protocol must now be specified always, and cannot be None.
Selecting the share protocol as nbd will have the same effect as,
selecting none previously.
Modify mocha test scripts to match these requirements.

In nexus test script, remove two test cases added around testing of
share value handling by mayastor
    1) testing ShareProtocol::None handling
    2) testing invalid value of share protocol
        This because some javascript library converts invalid values
        to 0 :-(. This can and has been tested with a hacked version of mctl.

Use std::Option<ShareProtocol> instead of ShareProtcol:None to indicate
unset share protocol in the nexus.

All invalid values of share protocol for the frontend/export purpose,
are now be handled intrinsically at the nexus rpc handling code,
so remove check in nexus share code.
